### PR TITLE
fixing a bug where meme picture wasn't being encoded

### DIFF
--- a/src/main/java/hudson/plugins/memegen/Meme.java
+++ b/src/main/java/hudson/plugins/memegen/Meme.java
@@ -59,7 +59,7 @@ public class Meme implements Serializable {
     }
 
     public String getImageURL() {
-        return "http://apimeme.com/meme?meme=" + identifier + "&top=" + encode(upperText) + "&bottom=" + encode(lowerText);
+        return "http://apimeme.com/meme?meme=" + encode(identifier) + "&top=" + encode(upperText) + "&bottom=" + encode(lowerText);
     }
 
     public Meme clone() {

--- a/src/main/java/hudson/plugins/memegen/MemeList.java
+++ b/src/main/java/hudson/plugins/memegen/MemeList.java
@@ -29,6 +29,8 @@ package hudson.plugins.memegen;
  */
 public class MemeList {
 
+    public static final String DEFAULT_MEME = "The Most Interesting Man In The World";
+
     public static String[] getMemeList() {
         return new String[]{
             "10 Guy",
@@ -830,9 +832,5 @@ public class MemeList {
             "Zuckerberg",
             "Zura Janai Katsura Da"
         };
-    }
-
-    public static String getDefaultMeme() {
-        return "The Most Interesting Man In The World";
     }
 }

--- a/src/main/java/hudson/plugins/memegen/MemeNotifier.java
+++ b/src/main/java/hudson/plugins/memegen/MemeNotifier.java
@@ -151,12 +151,12 @@ public class MemeNotifier extends Notifier {
         }
 
         private ArrayList<Meme> getDefaultSuccessMemes() {
-            smemes.add(new Meme(MemeList.getDefaultMeme(), "But when I do, I win", "I don't always commit"));
+            smemes.add(new Meme(MemeList.DEFAULT_MEME, "But when I do, I win", "I don't always commit"));
             return smemes;
         }
 
         private ArrayList<Meme> getDefaultFailMemes() {
-            fmemes.add(new Meme(MemeList.getDefaultMeme(), "But when I do, I break the build", "I don't always commit"));
+            fmemes.add(new Meme(MemeList.DEFAULT_MEME, "But when I do, I break the build", "I don't always commit"));
             return fmemes;
         }
 


### PR DESCRIPTION
The meme text was being encoded, but not the meme selector.  If there was a space in the name, the generated URL would be incomplete.  I also took away `MemeList.getDefaultMeme()` that only returned one single String, and made that String a `public static final String` member of `MemeList`
