### PR TITLE
allow defining global HTML attributes for any meme image

### DIFF
--- a/src/main/java/hudson/plugins/memegen/Meme.java
+++ b/src/main/java/hudson/plugins/memegen/Meme.java
@@ -34,20 +34,27 @@ import org.kohsuke.stapler.DataBoundConstructor;
  */
 public class Meme implements Serializable {
 
-    protected int generatorID;
+    /**
+	 * 
+	 */
+	private static final long serialVersionUID = -7408263024860013752L;
+	
+	protected int generatorID;
     protected int imageID;
     protected boolean parsed = false;
     public String identifier;
     public String upperText;
     public String lowerText;
+    public String additionalAttributes;
 
     protected String imageURL;
 
     @DataBoundConstructor
-    public Meme(String identifier, String lowerText, String upperText) {
+    public Meme(String identifier, String lowerText, String upperText, String additionalAttributes) {
         this.identifier = identifier;
         this.upperText = upperText;
         this.lowerText = lowerText;
+        this.additionalAttributes = additionalAttributes;
     }
 
     public String getUpperText() {
@@ -61,9 +68,13 @@ public class Meme implements Serializable {
     public String getImageURL() {
         return "http://apimeme.com/meme?meme=" + identifier + "&top=" + encode(upperText) + "&bottom=" + encode(lowerText);
     }
+    
+    public String getAdditionalAttributes() {
+		return (additionalAttributes != null ? additionalAttributes : "");
+	}
 
     public Meme clone() {
-        return new Meme(identifier, lowerText, upperText);
+        return new Meme(identifier, lowerText, upperText, additionalAttributes);
     }
 
     private static String encode(String text) {
@@ -73,4 +84,5 @@ public class Meme implements Serializable {
             return text;
         }
     }
+
 }

--- a/src/main/java/hudson/plugins/memegen/MemeFactory.java
+++ b/src/main/java/hudson/plugins/memegen/MemeFactory.java
@@ -23,16 +23,15 @@
  */
 package hudson.plugins.memegen;
 
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Iterator;
+import java.util.Random;
+import java.util.Set;
+
 import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
 import hudson.model.Result;
 import hudson.model.User;
-import java.util.ArrayList;
-import java.util.Set;
-import java.util.Iterator;
-import java.util.Calendar;
-import java.util.List;
-import java.util.Random;
 
 class NoMemesException extends Exception {
 
@@ -47,14 +46,14 @@ class NoMemesException extends Exception {
  */
 public class MemeFactory {
 
-    public static Meme getMeme(ArrayList<Meme> memes, AbstractBuild build) throws NoMemesException {
-        String resultString = build.getResult().toString();
+    public static Meme getMeme(ArrayList<Meme> memes, String additionalAttributes, AbstractBuild build) throws NoMemesException {
         Meme meme = selectMeme(memes, build.getResult());
         String buildName = build.getDisplayName();
         String projectName = build.getProject().getDisplayName();
         String users = userSetToString(build.getCulprits());
         meme.lowerText = textReplace(meme.lowerText, buildName, projectName, users);
         meme.upperText = textReplace(meme.upperText, buildName, projectName, users);
+        meme.additionalAttributes = additionalAttributes;
         return meme;
     }
 

--- a/src/main/resources/hudson/plugins/memegen/MemeNotifier/global.jelly
+++ b/src/main/resources/hudson/plugins/memegen/MemeNotifier/global.jelly
@@ -16,6 +16,9 @@
 		<f:entry title="Add the memes to the build description" help="/plugin/memegen/help-buildDescriptionEnabled.html">
 			<f:checkbox name="buildDescriptionEnabled" checked="${descriptor.isBuildDescriptionEnabled()}"/>
 		</f:entry>
+		<f:entry title="Additional global HTML attributes for images" help="/plugin/memegen/help-additionalGlobalAttributes.html">
+			<f:textbox name="additionalGlobalAttributes" value="${descriptor.additionalGlobalAttributes}" />
+		</f:entry>
 		<f:entry title="Memes for successful builds">
 			<f:repeatable var="smeme" items="${descriptor.getSuccessMemes()}" name="smemes" add="Add Meme">
 				<table width="100%" style="border: 1px solid #aaa">

--- a/src/main/webapp/help-additionalGlobalAttributes.html
+++ b/src/main/webapp/help-additionalGlobalAttributes.html
@@ -1,0 +1,3 @@
+<div>
+Set here the additional HTML properties you would like to any memes. For instance to limit the size of the meme and make it float to the right: height="300" style="float: right; margin-left: 20px" 
+</div>


### PR DESCRIPTION
Hi,

The issue I had with the meme generator plugin is that sometimes meme images are big, and as they are displayed in the job / build description, everything else below is shifted down, sometimes out of screen. 
I wanted to add a way to limit the size a meme image, so basically just a height attribute in the img element. But i then though about a more generic approach, where any html attributes could be added to the img element.
So I created a new field in global configuration, to hold these custom html attributes.

A future improvement could be to allow overriding these global attributes for each specific meme.
